### PR TITLE
feat: implement get dataset items operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ _Example workflow that retrieves the system prompt for the agent from Langfuse:_
 
 ![n8n-changelog](https://github.com/user-attachments/assets/4d224c2f-86b6-4ad4-a64a-45c7fe6e3595)
 
+## Get dataset items
+
+This node can be used to get [dataset](https://langfuse.com/docs/evaluation/dataset-runs/datasets) items page by page.
+
+Steps
+
+1. Enter the `name` of the dataset
+2. Enter the `page` and `limit` paramters
+
 ## Credentials
 
 To use this node, you need to authenticate with Langfuse. You'll need:

--- a/nodes/Langfuse/Dataset.ts
+++ b/nodes/Langfuse/Dataset.ts
@@ -1,0 +1,95 @@
+import { INodeProperties } from "n8n-workflow";
+
+export const datasetFields: INodeProperties[] = [
+
+    {
+        displayName: 'Dataset name',
+        name: 'datasetName',
+        type: 'string',
+        required: true,
+        default: '',
+        description: 'The name of the dataset to retrieve from LangFuse',
+        displayOptions: {
+            show: {
+                resource: ['dataset'],
+                operation: ['getItems'],
+            },
+        },
+        routing: {
+            request: {
+                qs: {
+                    datasetName: '={{$value}}',
+                },
+            },
+        },
+    },
+    {
+        displayName: 'Page',
+        name: 'page',
+        type: 'number',
+        required: true,
+        default: 1,
+        displayOptions: {
+            show: {
+                resource: ['dataset'],
+                operation: ['getItems'],
+            },
+        },
+        routing: {
+            request: {
+                qs: {
+                    page: '={{$value}}',
+                },
+            },
+        },
+    },
+    {
+        displayName: 'Limit',
+        name: 'limit',
+        type: 'number',
+        required: true,
+        default: 10,
+        displayOptions: {
+            show: {
+                resource: ['dataset'],
+                operation: ['getItems'],
+            },
+        },
+        routing: {
+            request: {
+                qs: {
+                    limit: '={{$value}}',
+                },
+            },
+        },
+    },
+];
+
+export const datasetOperations: INodeProperties[] = [
+    {
+        displayName: 'Operation',
+        name: 'operation',
+        type: 'options',
+        noDataExpression: true,
+        displayOptions: {
+            show: {
+                resource: ['dataset'],
+            },
+        },
+        options: [
+            {
+                name: 'Get items',
+                value: 'getItems',
+                action: 'Get dataset items',
+                description: 'Retrieve items from a dataset',
+                routing: {
+                    request: {
+                        method: 'GET',
+                        url: '=/api/public/dataset-items',
+                    },
+                },
+            },
+        ],
+        default: 'getItems',
+    }
+]

--- a/nodes/Langfuse/Langfuse.node.ts
+++ b/nodes/Langfuse/Langfuse.node.ts
@@ -1,4 +1,6 @@
 import { INodeType, INodeTypeDescription, NodeConnectionType } from 'n8n-workflow';
+import { promptFields, promptOperations } from './Prompt';
+import { datasetFields, datasetOperations } from './Dataset';
 
 export class Langfuse implements INodeType {
 	description: INodeTypeDescription = {
@@ -7,9 +9,9 @@ export class Langfuse implements INodeType {
 		icon: 'file:langfuse.svg',
 		group: ['transform'],
 		version: 1,
-		description: 'Fetches a prompt from Langfuse Prompt Management',
+		description: 'Interact with Langfuse API',
 		defaults: {
-			name: 'Get Prompt (Langfuse)',
+			name: 'Interact with Langfuse API',
 		},
 		inputs: [NodeConnectionType.Main],
 		outputs: [NodeConnectionType.Main],
@@ -33,70 +35,17 @@ export class Langfuse implements INodeType {
 						name: 'Prompt',
 						value: 'prompt',
 					},
+					{
+						name: 'Dataset',
+						value: 'dataset',
+					},
 				],
 				default: 'prompt',
 			},
-			{
-				displayName: 'Operation',
-				name: 'operation',
-				type: 'options',
-				noDataExpression: true,
-				displayOptions: {
-					show: {
-						resource: ['prompt'],
-					},
-				},
-				options: [
-					{
-						name: 'Get',
-						value: 'get',
-						action: 'Get a prompt',
-						description: 'Retrieve a prompt by name',
-						routing: {
-							request: {
-								method: 'GET',
-								url: '=/api/public/v2/prompts/{{$parameter["promptName"]}}',
-							},
-						},
-					},
-				],
-				default: 'get',
-			},
-			{
-				displayName: 'Prompt Name',
-				name: 'promptName',
-				type: 'string',
-				required: true,
-				default: '',
-				description: 'The name of the prompt to retrieve from LangFuse',
-				displayOptions: {
-					show: {
-						resource: ['prompt'],
-						operation: ['get'],
-					},
-				},
-			},
-			{
-				displayName: 'Prompt Label',
-				name: 'label',
-				type: 'string',
-				required: true,
-				default: 'production',
-				description: 'Deployment label of the prompt version to retrieve (defaults to Production)',
-				displayOptions: {
-					show: {
-						resource: ['prompt'],
-						operation: ['get'],
-					},
-				},
-				routing: {
-					request: {
-						qs: {
-							label: '={{$value}}',
-						},
-					},
-				},
-			},
+			...promptFields,
+			...promptOperations,
+			...datasetFields,
+			...datasetOperations,
 		],
 	};
 }

--- a/nodes/Langfuse/Prompt.ts
+++ b/nodes/Langfuse/Prompt.ts
@@ -1,0 +1,68 @@
+import { INodeProperties } from "n8n-workflow";
+
+export const promptFields: INodeProperties[] = [
+    {
+        displayName: 'Prompt Name',
+        name: 'promptName',
+        type: 'string',
+        required: true,
+        default: '',
+        description: 'The name of the prompt to retrieve from LangFuse',
+        displayOptions: {
+            show: {
+                resource: ['prompt'],
+                operation: ['get'],
+            },
+        },
+    },
+    {
+        displayName: 'Prompt Label',
+        name: 'label',
+        type: 'string',
+        required: true,
+        default: 'production',
+        description: 'Deployment label of the prompt version to retrieve (defaults to Production)',
+        displayOptions: {
+            show: {
+                resource: ['prompt'],
+                operation: ['get'],
+            },
+        },
+        routing: {
+            request: {
+                qs: {
+                    label: '={{$value}}',
+                },
+            },
+        },
+    },
+];
+
+export const promptOperations: INodeProperties[] = [
+    {
+        displayName: 'Operation',
+        name: 'operation',
+        type: 'options',
+        noDataExpression: true,
+        displayOptions: {
+            show: {
+                resource: ['prompt'],
+            },
+        },
+        options: [
+            {
+                name: 'Get',
+                value: 'get',
+                action: 'Get a prompt',
+                description: 'Retrieve a prompt by name',
+                routing: {
+                    request: {
+                        method: 'GET',
+                        url: '=/api/public/v2/prompts/{{$parameter["promptName"]}}',
+                    },
+                },
+            },
+        ],
+        default: 'get',
+    },
+]


### PR DESCRIPTION
Hi there, @marcklingen!

Summary of changes:
* moved options for Prompt operations to standalone file
* implemented Get items operation for datasets

It would be great to have feature in the node, tell me if you would like anything changed to get this merged.

Thanks!

<img width="1185" height="992" alt="image" src="https://github.com/user-attachments/assets/e19758d0-9b45-4d4a-a7fc-c0868bf09e26" />
